### PR TITLE
feat: Allow APIs with raw input

### DIFF
--- a/packages/uma/config/default.json
+++ b/packages/uma/config/default.json
@@ -88,27 +88,41 @@
         "@id": "urm:uma:default:JsonHttpErrorHandler",
         "@type": "JsonHttpErrorHandler",
         "handler": {
-          "@id": "urm:uma:default:JsonFormHttpHandler",
-          "@type": "JsonFormHttpHandler",
-          "handler": {
-            "@id": "urn:uma:default:RoutedHttpRequestHandler",
-            "@type": "RoutedHttpRequestHandler",
-            "routes": [
-              { "@id": "urn:uma:default:UmaConfigRoute" },
-              { "@id": "urn:uma:default:JwksRoute" },
-              { "@id": "urn:uma:default:TokenRoute" },
-              { "@id": "urn:uma:default:PermissionRegistrationRoute" },
-              { "@id": "urn:uma:default:ResourceRegistrationRoute" },
-              { "@id": "urn:uma:default:ResourceRegistrationOpsRoute" },
-              { "@id": "urn:uma:default:IntrospectionRoute" },
-              { "@id": "urn:uma:default:LogRoute" },
-              { "@id": "urn:uma:default:VCRoute" },
-              { "@id": "urn:uma:default:ContractRoute" }
-            ],
-            "defaultHandler": {
-              "@type": "DefaultRequestHandler"
+          "@id": "urm:uma:default:RouteHandler",
+          "@type": "WaterfallHandler",
+          "handlers": [
+            {
+              "comment": "Handles all JSON and form encoded input/output.",
+              "@id": "urm:uma:default:JsonFormHttpHandler",
+              "@type": "JsonFormHttpHandler",
+              "handler": {
+                "@id": "urn:uma:default:JsonRoutedHttpRequestHandler",
+                "@type": "RoutedHttpRequestHandler",
+                "routes": [
+                  { "@id": "urn:uma:default:UmaConfigRoute" },
+                  { "@id": "urn:uma:default:JwksRoute" },
+                  { "@id": "urn:uma:default:TokenRoute" },
+                  { "@id": "urn:uma:default:PermissionRegistrationRoute" },
+                  { "@id": "urn:uma:default:ResourceRegistrationRoute" },
+                  { "@id": "urn:uma:default:ResourceRegistrationOpsRoute" },
+                  { "@id": "urn:uma:default:IntrospectionRoute" }
+                ],
+                "defaultHandler": {
+                  "@type": "DefaultRequestHandler"
+                }
+              }
+            },
+            {
+              "comment": "Handles all remaining output. These handlers have to handle input/output parsing themselves. TODO: At some point we want more generic conneg.",
+              "@id": "urn:uma:default:RawRoutedHttpRequestHandler",
+              "@type": "RoutedHttpRequestHandler",
+              "routes": [
+                { "@id": "urn:uma:default:ContractRoute" },
+                { "@id": "urn:uma:default:LogRoute" },
+                { "@id": "urn:uma:default:VCRoute" }
+              ]
             }
-          }
+          ]
         }
       }
     },


### PR DESCRIPTION
Some APIs might need non-JSON/form input, this allows this possibility. In the future we probably want a more generic solution, but for now this at least allows the possibility.

This is necessary for the work being done on the policy APIs.