### PR TITLE
Allows the server to return tokens granting partial permissions

### DIFF
--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -43,6 +43,7 @@ so some information might change depending on which version and branch you're us
       - [Authentication methods](#authentication-methods)
       - [Customizing OIDC verification](#customizing-oidc-verification)
     + [Generate token](#generate-token)
+      - [Partial permission tokens](#partial-permission-tokens)
     + [Use token](#use-token)
   * [Policies](#policies)
     + [Client application identification](#client-application-identification)
@@ -380,6 +381,32 @@ How these policies work will be covered later on.
 If successful, the server will return a 200 response with a JSON body containing, among others,
 an `access_token` field containing the access token, and a `token_type` field describing the token type.
 If the claims are insufficient, a 403 response will be given instead.
+
+#### Partial permission tokens
+
+It is possible to set up the server so it also returns tokens
+if only some of the requested permissions are granted,
+instead of returning a 403 response.
+This can be useful for setups where the RS requires only one of the requested permissions to perform a request.
+The disadvantage is that the client might receive a token
+that does not have all permissions to perform the intended action.
+
+To enable this, start the UMA server with both `default.json` and `enable-partial.json`.
+
+From the repository root:
+```bash
+yarn start:uma -- -c ./config/default.json -c ./config/enable-partial.json
+```
+
+From `packages/uma`:
+```bash
+yarn start -c ./config/default.json -c ./config/enable-partial.json
+```
+
+With this enabled:
+- If at least one requested permission can be authorized, the AS returns `200` with an access token.
+- If not all requested permissions are granted, that response body includes `partial: true`.
+- If no requested permission can be authorized, the AS returns `403`.
 
 ### Use token
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "build": "yarn workspaces foreach --include 'packages/*' -A -pi -j unlimited -t run build",
     "test": "vitest run",
     "start": "yarn workspaces foreach --include 'packages/*' -A -pi -j unlimited run start",
+    "start:uma": "yarn workspace @solidlab/uma run start",
+    "start:css": "yarn workspace @solidlab/uma-css run start",
     "start:odrl": "yarn workspace @solidlab/uma run start:odrl & yarn workspace @solidlab/uma-css run start",
     "start:demo": "yarn workspaces foreach --include 'packages/*' -A -pi -j unlimited run demo",
     "script:demo": "yarn exec tsx ./demo/flow.ts",

--- a/packages/uma/config/enable-partial.json
+++ b/packages/uma/config/enable-partial.json
@@ -1,0 +1,12 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@solidlab/uma/^0.0.0/components/context.jsonld"
+  ],
+  "@graph": [
+    {
+      "@id": "urn:uma:default:ImmediateAuthorizerStrategy",
+      "@type": "ImmediateAuthorizerStrategy",
+      "allowPartialSuccess": true
+    }
+  ]
+}

--- a/packages/uma/config/tickets/strategy/immediate-authorizer.json
+++ b/packages/uma/config/tickets/strategy/immediate-authorizer.json
@@ -9,6 +9,7 @@
       "registrationStore": { "@id": "urn:uma:default:ResourceRegistrationStore" },
       "derivationStore": { "@id": "urn:uma:default:DerivationStore" },
       "strategy": {
+        "@id": "urn:uma:default:ImmediateAuthorizerStrategy",
         "@type": "ImmediateAuthorizerStrategy",
         "authorizer": { "@id": "urn:uma:default:Authorizer" }
       }

--- a/packages/uma/src/dialog/BaseNegotiator.ts
+++ b/packages/uma/src/dialog/BaseNegotiator.ts
@@ -9,6 +9,7 @@ import { TicketingStrategy } from '../ticketing/strategy/TicketingStrategy';
 import { Ticket } from '../ticketing/Ticket';
 import { TokenFactory } from '../tokens/TokenFactory';
 import { reType } from '../util/ReType';
+import { Permission } from '../views/Permission';
 import { DialogInput } from './Input';
 import { Negotiator } from './Negotiator';
 import { DialogOutput } from './Output';
@@ -55,6 +56,7 @@ export class BaseNegotiator implements Negotiator {
 
     // ... on success, create Access Token
     if (resolved.success) {
+      const partial = this.isPartialResult(updatedTicket.permissions, resolved.value);
 
       // Retrieve / create instantiated policy
       const { token, tokenType } = await this.tokenFactory.serialize({ permissions: resolved.value });
@@ -68,6 +70,7 @@ export class BaseNegotiator implements Negotiator {
       return ({
         access_token: token,
         token_type: tokenType,
+        ...(partial ? { partial: true } : {}),
       });
     }
 
@@ -85,6 +88,31 @@ export class BaseNegotiator implements Negotiator {
     throw new NeedInfoError('Need more info to authorize request ...', id, {
       required_claims: requirements,
     });
+  }
+
+  /**
+   * Checks if the granted permissions are a partial result of the requested permissions.
+   *
+   * Currently, the responsibility to verify that a result is partial lies here and not with the strategy.
+   * An alternative would be to let the strategy include an additional parameter indicating the result is partial.
+   */
+  protected isPartialResult(requested: Permission[], granted: Permission[]): boolean {
+    if (requested.length !== granted.length) {
+      return true;
+    }
+
+    for (const request of requested) {
+      const match = granted.find((grant): boolean =>
+        grant.resource_id === request.resource_id &&
+        grant.resource_scopes.length === request.resource_scopes.length &&
+        request.resource_scopes.every((scope): boolean => grant.resource_scopes.includes(scope))
+      );
+      if (!match) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   /**

--- a/packages/uma/src/dialog/Output.ts
+++ b/packages/uma/src/dialog/Output.ts
@@ -7,6 +7,7 @@ export const DialogOutput = ({
   access_token: string,
   refresh_token: $(string),
   token_type: string,
+  partial: $(boolean),
   expires_in: $(number),
   upgraded: $(boolean),
   derivation_resource_id: $(string),

--- a/packages/uma/src/policies/authorizers/NamespacedAuthorizer.ts
+++ b/packages/uma/src/policies/authorizers/NamespacedAuthorizer.ts
@@ -35,22 +35,27 @@ export class NamespacedAuthorizer implements Authorizer {
     // No permissions if no query
     if (!query || query.length === 0) return [];
 
-    // Base namespace on first resource
-    const ns = query[0].resource_id ? await this.findNamespace(query[0].resource_id) : undefined;
+    // Group requested permissions by applicable authorizer
+    const groupedQueries = new Map<Authorizer, Partial<Permission>[]>();
+    for (const permission of query) {
+      const ns = permission.resource_id ? await this.findNamespace(permission.resource_id) : undefined;
+      const authorizer = (ns && this.authorizers[ns]) || this.fallback;
+      const existing = groupedQueries.get(authorizer);
 
-    // Check namespaces of other resources
-    for (let i = 1; i < query.length; ++i) {
-      if ((query[i].resource_id ? await this.findNamespace(query[i].resource_id) : undefined) !== ns) {
-        this.logger.warn(`Cannot calculate permissions over multiple namespaces at once.`);
-        return [];
+      if (existing) {
+        existing.push(permission);
+      } else {
+        groupedQueries.set(authorizer, [ permission ]);
       }
     }
 
-    // Find applicable authorizer
-    const authorizer = (ns && this.authorizers[ns]) || this.fallback;
-
-    // Delegate to authorizer
-    return authorizer.permissions(claims, query);
+    // Delegate each namespace-specific subset and merge all granted permissions.
+    const permissionSets = await Promise.all(
+      [ ...groupedQueries.entries() ].map(
+        ([ authorizer, groupedQuery ]) => authorizer.permissions(claims, groupedQuery),
+      ),
+    );
+    return permissionSets.flat();
   }
 
   /**

--- a/packages/uma/src/ticketing/strategy/ImmediateAuthorizerStrategy.ts
+++ b/packages/uma/src/ticketing/strategy/ImmediateAuthorizerStrategy.ts
@@ -10,12 +10,17 @@ import { Authorizer } from "../../policies/authorizers/Authorizer";
 /**
  * A TicketingStrategy that simply stores provided Claims, and calculates all
  * available Permissions from them upon resolution.
+ *
+ * If `allowPartialSuccess` is set to true,
+ * the strategy will return all available permissions,
+ * even if not all required permissions are granted.
  */
 export class ImmediateAuthorizerStrategy implements TicketingStrategy {
   protected readonly logger = getLoggerFor(this);
 
   constructor(
     protected authorizer: Authorizer,
+    protected readonly allowPartialSuccess = false,
   ) {}
 
   /** @inheritdoc */
@@ -45,9 +50,12 @@ export class ImmediateAuthorizerStrategy implements TicketingStrategy {
 
     const permissions = await this.calculatePermissions(ticket);
 
+    // Always fail if no results at all, even with allowPartialSuccess
     if (permissions.length === 0) return Failure([]);
 
-    // TODO: if, in the future, we want to allow partial results, this will need to change
+    // With partial success enabled, any non-empty authorization result is accepted
+    if (this.allowPartialSuccess) return Success(permissions);
+
     // Verify all required scopes have been granted
     const unmatchedPermissions: Permission[] = [];
     for (const required of ticket.permissions) {

--- a/packages/uma/src/ticketing/strategy/ImmediateAuthorizerStrategy.ts
+++ b/packages/uma/src/ticketing/strategy/ImmediateAuthorizerStrategy.ts
@@ -67,11 +67,9 @@ export class ImmediateAuthorizerStrategy implements TicketingStrategy {
     }
 
     if (unmatchedPermissions.length > 0) {
-      // TODO: due to the current format, scopes are not linked to resources,
-      //       so this will be weird for requests with multiple target resources.
-      return Failure([{
-        resource_scopes: unmatchedPermissions.flatMap((perm) => perm.resource_scopes),
-      }]);
+      // TODO: RequiredClaim has no field indicating for which the scopes are missing, could add one.
+      //       The resource_scopes field itself is already custom (added because of aggregation spec)
+      return Failure(unmatchedPermissions.map((perm) => ({ resource_scopes: perm.resource_scopes })));
     }
 
     return Success(permissions);

--- a/packages/uma/test/unit/dialog/BaseNegotiator.test.ts
+++ b/packages/uma/test/unit/dialog/BaseNegotiator.test.ts
@@ -49,7 +49,7 @@ describe('BaseNegotiator', (): void => {
       validateClaims: vi.fn().mockResolvedValue(ticket),
       resolveTicket: vi.fn().mockResolvedValue({
         success: true,
-        value: { resource_id: 'id1', resource_scopes: [ 'scope1' ] },
+        value: [ { resource_id: 'id1', resource_scopes: [ 'scope1' ] } ],
       }),
     };
 
@@ -76,7 +76,7 @@ describe('BaseNegotiator', (): void => {
     expect(ticketingStrategy.validateClaims).toHaveBeenCalledTimes(0);
     expect(tokenFactory.serialize).toHaveBeenCalledTimes(1);
     expect(tokenFactory.serialize).toHaveBeenLastCalledWith(
-      { permissions: { resource_id: 'id1', resource_scopes: [ 'scope1' ] } });
+      { permissions: [ { resource_id: 'id1', resource_scopes: [ 'scope1' ] } ] });
   });
 
   it('errors if there is no existing ticket and no permission request.', async(): Promise<void> => {
@@ -128,7 +128,7 @@ describe('BaseNegotiator', (): void => {
     expect(ticketingStrategy.validateClaims).toHaveBeenCalledTimes(0);
     expect(tokenFactory.serialize).toHaveBeenCalledTimes(1);
     expect(tokenFactory.serialize).toHaveBeenLastCalledWith(
-      { permissions: { resource_id: 'id1', resource_scopes: [ 'scope1' ] } });
+      { permissions: [ { resource_id: 'id1', resource_scopes: [ 'scope1' ] } ] });
   });
 
   it('errors if invalid credentials are provided.', async(): Promise<void> => {
@@ -152,7 +152,7 @@ describe('BaseNegotiator', (): void => {
     expect(ticketingStrategy.validateClaims).toHaveBeenLastCalledWith(ticket, claims);
     expect(tokenFactory.serialize).toHaveBeenCalledTimes(1);
     expect(tokenFactory.serialize).toHaveBeenLastCalledWith(
-      { permissions: { resource_id: 'id1', resource_scopes: [ 'scope1' ] } });
+      { permissions: [ { resource_id: 'id1', resource_scopes: [ 'scope1' ] } ] });
   });
 
   it('supports multiple claim tokens.', async(): Promise<void> => {
@@ -170,5 +170,21 @@ describe('BaseNegotiator', (): void => {
     expect(verifier.verify).toHaveBeenCalledWith({ token: 'token2', format: 'format2' });
     expect(ticketingStrategy.validateClaims).toHaveBeenCalledTimes(2);
     expect(ticketingStrategy.validateClaims).toHaveBeenCalledWith(ticket, claims);
+  });
+
+  it('includes partial=true when resolved permissions do not cover all requested scopes.', async(): Promise<void> => {
+    ticketingStrategy.initializeTicket.mockResolvedValueOnce({
+      permissions: [ { resource_id: 'id1', resource_scopes: [ 'scope1', 'scope2' ] } ],
+      provided: {},
+    });
+    ticketingStrategy.resolveTicket.mockResolvedValueOnce({
+      success: true,
+      value: [ { resource_id: 'id1', resource_scopes: [ 'scope1' ] } ],
+    });
+
+    await expect(negotiator.negotiate({
+      permissions: [ { resource_id: 'id1', resource_scopes: [ 'scope1', 'scope2' ] } ]
+    }))
+      .resolves.toEqual({ access_token: 'token', token_type: 'type', partial: true });
   });
 });

--- a/packages/uma/test/unit/policies/authorizers/NamespacedAuthorizer.test.ts
+++ b/packages/uma/test/unit/policies/authorizers/NamespacedAuthorizer.test.ts
@@ -6,6 +6,9 @@ import { Registration, RegistrationStore } from '../../../../src/util/Registrati
 
 describe('NamespacedAuthorizer', (): void => {
   const claims: ClaimSet = { claim: 'set' };
+  const perm1 = [{ resource_id: 'res1', resource_scopes: [ 'scope1' ] }];
+  const perm2 = [{ resource_id: 'res2', resource_scopes: [ 'scope2' ] }];
+  const fallbackPerm = [{ resource_id: 'fallback', resource_scopes: [ 'scopef' ] }];
 
   let authorizers: Record<string, Mocked<Authorizer>>;
   let fallback: Mocked<Authorizer>;
@@ -14,11 +17,11 @@ describe('NamespacedAuthorizer', (): void => {
 
   beforeEach(async(): Promise<void> => {
     authorizers = {
-      ns1: { permissions: vi.fn().mockResolvedValue('perm1'), },
-      ns2: { permissions: vi.fn().mockResolvedValue('perm2'), },
+      ns1: { permissions: vi.fn().mockResolvedValue(perm1), },
+      ns2: { permissions: vi.fn().mockResolvedValue(perm2), },
     };
 
-    fallback = { permissions: vi.fn().mockResolvedValue('perm'), };
+    fallback = { permissions: vi.fn().mockResolvedValue(fallbackPerm), };
 
     const descriptions: Record<string, Registration> = {
       res1: { description: { name: 'http://example.com/foo/ns1/res', resource_scopes: [] }, owner: 'owner1' },
@@ -33,11 +36,9 @@ describe('NamespacedAuthorizer', (): void => {
   });
 
   describe('.permissions', (): void => {
-    it('returns an empty list if there is no query or multiple identifiers.', async(): Promise<void> => {
+    it('returns an empty list if there is no query.', async(): Promise<void> => {
       await expect(authorizer.permissions(claims)).resolves.toEqual([]);
       await expect(authorizer.permissions(claims, [])).resolves.toEqual([]);
-      const query = [{ resource_id: 'res1' }, { resource_id: 'res2' }];
-      await expect(authorizer.permissions(claims, query)).resolves.toEqual([]);
       expect(authorizers.ns1.permissions).toHaveBeenCalledTimes(0);
       expect(authorizers.ns2.permissions).toHaveBeenCalledTimes(0);
       expect(fallback.permissions).toHaveBeenCalledTimes(0);
@@ -45,7 +46,7 @@ describe('NamespacedAuthorizer', (): void => {
 
     it('calls the matching authorizer.', async(): Promise<void> => {
       const query = [{ resource_id: 'res2', resource_scopes: [ 'scope1' ] }];
-      await expect(authorizer.permissions(claims, query)).resolves.toEqual('perm2');
+      await expect(authorizer.permissions(claims, query)).resolves.toEqual(perm2);
       expect(authorizers.ns1.permissions).toHaveBeenCalledTimes(0);
       expect(authorizers.ns2.permissions).toHaveBeenCalledTimes(1);
       expect(authorizers.ns2.permissions).toHaveBeenLastCalledWith(claims, query);
@@ -55,21 +56,41 @@ describe('NamespacedAuthorizer', (): void => {
     it('calls the fallback authorizer if there is no match.', async(): Promise<void> => {
       const query1 = [{ resource_id: 'res3' }];
       const query2 = [{ resource_id: 'unknown' }];
-      await expect(authorizer.permissions(claims, query1)).resolves.toEqual('perm');
-      await expect(authorizer.permissions(claims, query2)).resolves.toEqual('perm');
+      await expect(authorizer.permissions(claims, query1)).resolves.toEqual(fallbackPerm);
+      await expect(authorizer.permissions(claims, query2)).resolves.toEqual(fallbackPerm);
       expect(authorizers.ns1.permissions).toHaveBeenCalledTimes(0);
       expect(authorizers.ns2.permissions).toHaveBeenCalledTimes(0);
       expect(fallback.permissions).toHaveBeenCalledTimes(2);
       expect(fallback.permissions).toHaveBeenCalledWith(claims, query1);
       expect(fallback.permissions).toHaveBeenCalledWith(claims, query2);
     });
+
+    it('merges permissions of mixed namespaces.', async(): Promise<void> => {
+      const query = [
+        { resource_id: 'res1', resource_scopes: [ 'scope1' ] },
+        { resource_id: 'res2', resource_scopes: [ 'scope2' ] },
+        { resource_id: 'res3', resource_scopes: [ 'scope3' ] },
+      ];
+
+      await expect(authorizer.permissions(claims, query)).resolves.toEqual([ ...perm1, ...perm2, ...fallbackPerm ]);
+
+      expect(authorizers.ns1.permissions).toHaveBeenCalledTimes(1);
+      expect(authorizers.ns1.permissions).toHaveBeenCalledWith(claims, [ query[0] ]);
+      expect(authorizers.ns2.permissions).toHaveBeenCalledTimes(1);
+      expect(authorizers.ns2.permissions).toHaveBeenCalledWith(claims, [ query[1] ]);
+      expect(fallback.permissions).toHaveBeenCalledTimes(1);
+      expect(fallback.permissions).toHaveBeenCalledWith(claims, [ query[2] ]);
+    });
   });
 
   it('can be configured to use a different path segment.', async(): Promise<void> => {
-    authorizers.res = { permissions: vi.fn().mockResolvedValue('perm-res'), };
+    authorizers.res = {
+      permissions: vi.fn().mockResolvedValue([{ resource_id: 'res1', resource_scopes: [ 'perm-res' ] }]),
+    };
     const authorizer = new NamespacedAuthorizer(authorizers, fallback, registrationStore, 3);
     const query = [{ resource_id: 'res1' }];
-    await expect(authorizer.permissions(claims, query)).resolves.toEqual('perm-res');
+    await expect(authorizer.permissions(claims, query))
+      .resolves.toEqual([{ resource_id: 'res1', resource_scopes: [ 'perm-res' ] }]);
     expect(authorizers.res.permissions).toHaveBeenCalledTimes(1);
     expect(authorizers.res.permissions).toHaveBeenLastCalledWith(claims, query);
   });

--- a/packages/uma/test/unit/ticketing/strategy/ImmediateAuthorizerStrategy.test.ts
+++ b/packages/uma/test/unit/ticketing/strategy/ImmediateAuthorizerStrategy.test.ts
@@ -64,4 +64,29 @@ describe('ImmediateAuthorizerStrategy', (): void => {
     await expect(strategy.resolveTicket(ticket)).resolves
       .toEqual({ success: false, value: [{ resource_scopes: ['scopes'] }] });
   });
+
+  it('resolves with partial permissions when allowPartialSuccess is enabled.', async(): Promise<void> => {
+    const partialStrategy = new ImmediateAuthorizerStrategy(authorizer, true);
+    const ticket: Ticket = {
+      permissions: [{ resource_id: 'id', resource_scopes: [ 'read', 'write' ] }],
+      provided: {},
+    };
+    const authResponse: Permission[] = [
+      { resource_id: 'id', resource_scopes: [ 'read' ] },
+    ];
+    authorizer.permissions.mockResolvedValueOnce(authResponse);
+    await expect(partialStrategy.resolveTicket(ticket)).resolves
+      .toEqual({ success: true, value: authResponse });
+  });
+
+  it('rejects when no permissions are resolved, even with allowPartialSuccess enabled.', async(): Promise<void> => {
+    const partialStrategy = new ImmediateAuthorizerStrategy(authorizer, true);
+    const ticket: Ticket = {
+      permissions,
+      provided: {},
+    };
+    authorizer.permissions.mockResolvedValueOnce([]);
+    await expect(partialStrategy.resolveTicket(ticket)).resolves
+      .toEqual({ success: false, value: [] });
+  });
 });

--- a/test/integration/Partial.test.ts
+++ b/test/integration/Partial.test.ts
@@ -18,7 +18,8 @@ interface UmaConfig {
 describe('A server with partial results enabled', (): void => {
   const owner = 'http://example.com/alice#me';
   const user = `http://example.com/bob`;
-  const resource = `http://localhost:${rsPort}/alice/data`;
+  const aliceResource = `http://localhost:${rsPort}/alice/data`;
+  const bobResource = `http://localhost:${rsPort}/bob/data`;
   const readScope = 'http://www.w3.org/ns/odrl/2/read';
   const writeScope = 'http://www.w3.org/ns/odrl/2/write';
   let umaApp: App;
@@ -75,18 +76,31 @@ describe('A server with partial results enabled', (): void => {
     const patJson = await patResponse.json() as { access_token: string, token_type: string };
     pat = `${patJson.token_type} ${patJson.access_token}`;
 
-    const registrationBody = {
-      name: resource,
-      resource_scopes: [ readScope, writeScope ],
-    };
-    const resourceRegistrationResponse = await fetch(umaConfig.resource_registration_endpoint, {
+    let resourceRegistrationResponse = await fetch(umaConfig.resource_registration_endpoint, {
       method: 'POST',
       headers: {
         Authorization: pat,
         'Content-Type': 'application/json',
         Accept: 'application/json',
       },
-      body: JSON.stringify(registrationBody),
+      body: JSON.stringify({
+        name: aliceResource,
+        resource_scopes: [ readScope, writeScope ],
+      }),
+    });
+    expect(resourceRegistrationResponse.status).toBe(201);
+
+    resourceRegistrationResponse = await fetch(umaConfig.resource_registration_endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: pat,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        name: bobResource,
+        resource_scopes: [ readScope, writeScope ],
+      }),
     });
     expect(resourceRegistrationResponse.status).toBe(201);
 
@@ -99,7 +113,7 @@ describe('A server with partial results enabled', (): void => {
         }
 
         const auth = request.headers.authorization;
-        if (hasScope(auth, resource, readScope)) {
+        if (hasScope(auth, aliceResource, readScope)) {
           response.statusCode = 200;
           response.end('protected data');
           return;
@@ -114,7 +128,7 @@ describe('A server with partial results enabled', (): void => {
           },
           body: JSON.stringify([
             {
-              resource_id: resource,
+              resource_id: aliceResource,
               resource_scopes: [ readScope ],
             }
           ]),
@@ -174,13 +188,13 @@ describe('A server with partial results enabled', (): void => {
         odrl:assigner <${owner}> ;
         odrl:action odrl:create, odrl:modify ;
         odrl:target <http://localhost:${rsPort}/alice/> ,
-                    <${resource}> .
+                    <${aliceResource}> .
 
       ex:userPermission a odrl:Permission ;
         odrl:assignee <${user}> ;
         odrl:assigner <${owner}> ;
         odrl:action odrl:read ;
-        odrl:target <${resource}> .`;
+        odrl:target <${aliceResource}> .`;
 
     const url = `http://localhost:${umaPort}/uma/policies`;
     let response = await fetch(url, {
@@ -190,11 +204,11 @@ describe('A server with partial results enabled', (): void => {
     });
     expect(response.status).toBe(201);
 
-    response = await umaFetch(resource, {}, user);
+    response = await umaFetch(aliceResource, {}, user);
     expect(response.status).toBe(200);
   });
 
-  it('returns partial=true when not all requested scopes are granted.', async(): Promise<void> => {
+  it('returns partial=true for mixed namespaces when not all scopes are granted.', async(): Promise<void> => {
     const permissionResponse = await fetch(umaConfig.permission_endpoint, {
       method: 'POST',
       headers: {
@@ -204,9 +218,13 @@ describe('A server with partial results enabled', (): void => {
       },
       body: JSON.stringify([
         {
-          resource_id: resource,
+          resource_id: aliceResource,
           resource_scopes: [ readScope, writeScope ],
-        }
+        },
+        {
+          resource_id: bobResource,
+          resource_scopes: [ readScope ],
+        },
       ]),
     });
     expect(permissionResponse.status).toBe(201);
@@ -220,14 +238,14 @@ describe('A server with partial results enabled', (): void => {
     // Verify the token contains the allowed scope
     const jwtPayload = JSON.parse(Buffer.from(token.access_token.split('.')[1], 'base64').toString());
     expect(Array.isArray(jwtPayload.permissions)).toBe(true);
-    expect(jwtPayload.permissions).toContainEqual({
-      resource_id: resource,
+    expect(jwtPayload.permissions).toEqual([{
+      resource_id: aliceResource,
       resource_scopes: [ readScope ]
-    });
+    }]);
   });
 
   it('can access a protected resource with partial results.', async(): Promise<void> => {
-    const response = await umaFetch(resource, {}, user);
+    const response = await umaFetch(aliceResource, {}, user);
     expect(response.status).toBe(200);
   });
 });

--- a/test/integration/Partial.test.ts
+++ b/test/integration/Partial.test.ts
@@ -1,0 +1,252 @@
+import { App } from '@solid/community-server';
+import { setGlobalLoggerFactory, WinstonLoggerFactory } from 'global-logger-factory';
+import { createServer, Server } from 'node:http';
+import path from 'node:path';
+import { getPorts, instantiateFromConfig } from '../util/ServerUtil';
+import { getToken, umaFetch } from '../util/UmaUtil';
+
+const [ rsPort, umaPort ] = getPorts('Partial');
+
+interface UmaConfig {
+  issuer: string;
+  permission_endpoint: string;
+  resource_registration_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint: string;
+}
+
+describe('A server with partial results enabled', (): void => {
+  const owner = 'http://example.com/alice#me';
+  const user = `http://example.com/bob`;
+  const resource = `http://localhost:${rsPort}/alice/data`;
+  const readScope = 'http://www.w3.org/ns/odrl/2/read';
+  const writeScope = 'http://www.w3.org/ns/odrl/2/write';
+  let umaApp: App;
+  let rsServer: Server;
+  let umaConfig: UmaConfig;
+  let pat: string;
+
+  beforeAll(async(): Promise<void> => {
+    setGlobalLoggerFactory(new WinstonLoggerFactory('off'));
+
+    umaApp = await instantiateFromConfig(
+      'urn:uma:default:App',
+      [
+        path.join(__dirname, '../../packages/uma/config/default.json'),
+        path.join(__dirname, '../../packages/uma/config/enable-partial.json'),
+      ],
+      {
+        'urn:uma:variables:port': umaPort,
+        'urn:uma:variables:baseUrl': `http://localhost:${umaPort}/uma`,
+        'urn:uma:variables:backupFilePath': '',
+      }
+    );
+    await umaApp.start();
+
+    const configResponse = await fetch(`http://localhost:${umaPort}/uma/.well-known/uma2-configuration`);
+    expect(configResponse.status).toBe(200);
+    umaConfig = await configResponse.json() as UmaConfig;
+
+    const registrationResponse = await fetch(umaConfig.registration_endpoint, {
+      method: 'POST',
+      headers: {
+        authorization: `WebID ${encodeURIComponent(owner)}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ client_uri: `http://localhost:${rsPort}/` }),
+    });
+    expect(registrationResponse.status).toBe(201);
+    const { client_id, client_secret } = await registrationResponse.json() as {
+      client_id: string,
+      client_secret: string,
+    };
+
+    const authString = `${encodeURIComponent(client_id)}:${encodeURIComponent(client_secret)}`;
+    const credentials = `Basic ${Buffer.from(authString).toString('base64')}`;
+    const patResponse = await fetch(umaConfig.token_endpoint, {
+      method: 'POST',
+      headers: {
+        authorization: credentials,
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: 'grant_type=client_credentials&scope=uma_protection',
+    });
+    expect(patResponse.status).toBe(201);
+    const patJson = await patResponse.json() as { access_token: string, token_type: string };
+    pat = `${patJson.token_type} ${patJson.access_token}`;
+
+    const registrationBody = {
+      name: resource,
+      resource_scopes: [ readScope, writeScope ],
+    };
+    const resourceRegistrationResponse = await fetch(umaConfig.resource_registration_endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: pat,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(registrationBody),
+    });
+    expect(resourceRegistrationResponse.status).toBe(201);
+
+    rsServer = createServer((request, response): void => {
+      void (async(): Promise<void> => {
+        if (!request.url || !request.url.startsWith('/alice/data')) {
+          response.statusCode = 404;
+          response.end();
+          return;
+        }
+
+        const auth = request.headers.authorization;
+        if (hasScope(auth, resource, readScope)) {
+          response.statusCode = 200;
+          response.end('protected data');
+          return;
+        }
+
+        const permissionResponse = await fetch(umaConfig.permission_endpoint, {
+          method: 'POST',
+          headers: {
+            Authorization: pat,
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          body: JSON.stringify([
+            {
+              resource_id: resource,
+              resource_scopes: [ readScope ],
+            }
+          ]),
+        });
+
+        if (permissionResponse.status !== 201) {
+          response.statusCode = 500;
+          response.end(await permissionResponse.text());
+          return;
+        }
+
+        const { ticket } = await permissionResponse.json() as { ticket: string };
+        response.statusCode = 401;
+        response.setHeader('WWW-Authenticate', `UMA realm="solid", as_uri="${umaConfig.issuer}", ticket="${ticket}"`);
+        response.end();
+      })().catch((error: unknown): void => {
+        response.statusCode = 500;
+        response.end(String(error));
+      });
+    });
+
+    await new Promise<void>((resolve): void => {
+      rsServer.listen(rsPort, resolve);
+    });
+  });
+
+  afterAll(async(): Promise<void> => {
+    const shutdown: Promise<unknown>[] = [];
+    if (umaApp) {
+      shutdown.push(umaApp.stop());
+    }
+    if (rsServer) {
+      shutdown.push(new Promise<void>((resolve, reject): void => {
+        rsServer.close((error): void => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      }));
+    }
+    await Promise.all(shutdown);
+  });
+
+  it('can create a policy for the protected resource.', async(): Promise<void> => {
+    const policy = `
+      @prefix ex:     <http://example.org/> .
+      @prefix odrl:   <http://www.w3.org/ns/odrl/2/> .
+      
+      ex:policy a odrl:Agreement ;
+        odrl:uid ex:policy ;
+        odrl:permission ex:ownerPermission, ex:userPermission .
+      
+      ex:ownerPermission a odrl:Permission ;
+        odrl:assignee <${owner}> ;
+        odrl:assigner <${owner}> ;
+        odrl:action odrl:create, odrl:modify ;
+        odrl:target <http://localhost:${rsPort}/alice/> ,
+                    <${resource}> .
+
+      ex:userPermission a odrl:Permission ;
+        odrl:assignee <${user}> ;
+        odrl:assigner <${owner}> ;
+        odrl:action odrl:read ;
+        odrl:target <${resource}> .`;
+
+    const url = `http://localhost:${umaPort}/uma/policies`;
+    let response = await fetch(url, {
+      method: 'POST',
+      headers: { authorization: `WebID ${encodeURIComponent(owner)}`, 'content-type': 'text/turtle' },
+      body: policy,
+    });
+    expect(response.status).toBe(201);
+
+    response = await umaFetch(resource, {}, user);
+    expect(response.status).toBe(200);
+  });
+
+  it('returns partial=true when not all requested scopes are granted.', async(): Promise<void> => {
+    const permissionResponse = await fetch(umaConfig.permission_endpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: pat,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify([
+        {
+          resource_id: resource,
+          resource_scopes: [ readScope, writeScope ],
+        }
+      ]),
+    });
+    expect(permissionResponse.status).toBe(201);
+    const { ticket } = await permissionResponse.json() as { ticket: string };
+
+    const token = await getToken(ticket, umaConfig.token_endpoint, user);
+
+    // Verify partial flag is present
+    expect((token as unknown as { partial?: boolean }).partial).toBe(true);
+
+    // Verify the token contains the allowed scope
+    const jwtPayload = JSON.parse(Buffer.from(token.access_token.split('.')[1], 'base64').toString());
+    expect(Array.isArray(jwtPayload.permissions)).toBe(true);
+    expect(jwtPayload.permissions).toContainEqual({
+      resource_id: resource,
+      resource_scopes: [ readScope ]
+    });
+  });
+
+  it('can access a protected resource with partial results.', async(): Promise<void> => {
+    const response = await umaFetch(resource, {}, user);
+    expect(response.status).toBe(200);
+  });
+});
+
+function hasScope(authHeader: string | undefined, resource: string, scope: string): boolean {
+  if (!authHeader?.startsWith('Bearer ')) {
+    return false;
+  }
+
+  try {
+    const token = authHeader.slice('Bearer '.length);
+    const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString()) as {
+      permissions?: { resource_id: string, resource_scopes: string[] }[]
+    };
+    return Array.isArray(payload.permissions)
+      && payload.permissions.some((permission): boolean =>
+        permission.resource_id === resource && permission.resource_scopes.includes(scope)
+      );
+  } catch {
+    return false;
+  }
+}

--- a/test/util/ServerUtil.ts
+++ b/test/util/ServerUtil.ts
@@ -12,6 +12,7 @@ const portNames = [
   'Demo',
   'ODRL',
   'OIDC',
+  'Partial',
   'Policies',
 ] as const;
 


### PR DESCRIPTION
Needed to resolve the issue when a RS wants to verify if a user has one out of a set of scopes to grant access.

This is a solution to that problem, potentially to be improved/modified/etc. in the future based on needs and conclusions.

Some thoughts/remarks around this idea and implementation:
 * My main concern is that in the future this might conflict with wanting to throw a NeedInfo error instead returning a partial token. This is also the reason I put this feature in a separate config that needs to be added to enable this.
 * Alternative could be that the client has to indicate in the request that they are OK with receiving a partial result, but the client might not now this.
 * A more extreme alternative might be that the RS can do more advanced ticket requests where boolean operators are introduced.
 * Currently the output includes a boolean to indicate that a token is partial.