### PR TITLE
Add sub value to output access tokens

### DIFF
--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -43,7 +43,9 @@ so some information might change depending on which version and branch you're us
       - [Authentication methods](#authentication-methods)
       - [Customizing OIDC verification](#customizing-oidc-verification)
     + [Generate token](#generate-token)
+      - [Enabling optional token features](#enabling-optional-token-features)
       - [Partial permission tokens](#partial-permission-tokens)
+      - [Include `sub` claim in access token](#include-sub-claim-in-access-token)
     + [Use token](#use-token)
   * [Policies](#policies)
     + [Client application identification](#client-application-identification)
@@ -381,10 +383,22 @@ How these policies work will be covered later on.
 If successful, the server will return a 200 response with a JSON body containing, among others,
 an `access_token` field containing the access token, and a `token_type` field describing the token type.
 
-The generated access token will also contain a `sub` claim.
-This value indicates the identity from the original identification input that was provided during token exchange.
-
 If the claims are insufficient, a 403 response will be given instead.
+
+#### Enabling optional token features
+
+Some token-related features are optional and can be enabled by adding extra configuration files
+when starting the UMA server, in addition to `default.json`.
+
+From the repository root:
+```bash
+yarn start:uma -- -c ./config/default.json -c ./config/<feature-config>.json
+```
+
+From `packages/uma`:
+```bash
+yarn start -c ./config/default.json -c ./config/<feature-config>.json
+```
 
 #### Partial permission tokens
 
@@ -395,22 +409,20 @@ This can be useful for setups where the RS requires only one of the requested pe
 The disadvantage is that the client might receive a token
 that does not have all permissions to perform the intended action.
 
-To enable this, start the UMA server with both `default.json` and `enable-partial.json`.
-
-From the repository root:
-```bash
-yarn start:uma -- -c ./config/default.json -c ./config/enable-partial.json
-```
-
-From `packages/uma`:
-```bash
-yarn start -c ./config/default.json -c ./config/enable-partial.json
-```
+To enable this, use `enable-partial.json` as the feature config.
 
 With this enabled:
 - If at least one requested permission can be authorized, the AS returns `200` with an access token.
 - If not all requested permissions are granted, that response body includes `partial: true`.
 - If no requested permission can be authorized, the AS returns `403`.
+
+#### Include `sub` claim in access token
+
+By default, generated access tokens do not include a `sub` claim.
+To include it, use `enable-sub.json` as the feature config.
+
+With this enabled:
+- Generated access tokens include `sub`, set to the identity extracted during token exchange.
 
 ### Use token
 

--- a/documentation/getting-started.md
+++ b/documentation/getting-started.md
@@ -380,6 +380,10 @@ Based on the stored policies, it then determines if the provided claims are suff
 How these policies work will be covered later on.
 If successful, the server will return a 200 response with a JSON body containing, among others,
 an `access_token` field containing the access token, and a `token_type` field describing the token type.
+
+The generated access token will also contain a `sub` claim.
+This value indicates the identity from the original identification input that was provided during token exchange.
+
 If the claims are insufficient, a 403 response will be given instead.
 
 #### Partial permission tokens

--- a/packages/uma/config/enable-sub.json
+++ b/packages/uma/config/enable-sub.json
@@ -1,0 +1,12 @@
+{
+  "@context": [
+    "https://linkedsoftwaredependencies.org/bundles/npm/@solidlab/uma/^0.0.0/components/context.jsonld"
+  ],
+  "@graph": [
+    {
+      "@id": "urn:uma:default:TokenFactory",
+      "@type": "JwtTokenFactory",
+      "addSub": true
+    }
+  ]
+}

--- a/packages/uma/src/credentials/Claims.ts
+++ b/packages/uma/src/credentials/Claims.ts
@@ -1,6 +1,20 @@
 
 export const WEBID = 'urn:solidlab:uma:claims:types:webid';
 export const CLIENTID = 'urn:solidlab:uma:claims:types:clientid';
+export const ORIGINAL = 'urn:solidlab:uma:claims:types:original';
 export const PURPOSE = 'http://www.w3.org/ns/odrl/2/purpose';
 export const LEGAL_BASIS = 'https://w3id.org/oac#LegalBasis';
 export const ACCESS = 'urn:solidlab:uma:claims:types:access';
+
+/**
+ * Resolves a claim value by preferring an ORIGINAL claim-set entry when present.
+ */
+export function getOriginalClaimValue(claims: NodeJS.Dict<unknown>, claimType: string): unknown {
+  const original = claims[ORIGINAL];
+  if (typeof original === 'object' && original !== null) {
+	const originalClaims = original as Record<string, unknown>;
+	return originalClaims[claimType];
+  }
+
+  return claims[claimType];
+}

--- a/packages/uma/src/credentials/verify/IriVerifier.ts
+++ b/packages/uma/src/credentials/verify/IriVerifier.ts
@@ -1,6 +1,6 @@
 import { joinUrl } from '@solid/community-server';
 import { isIri } from '../../util/ConvertUtil';
-import { CLIENTID, WEBID } from '../Claims';
+import { CLIENTID, ORIGINAL, WEBID } from '../Claims';
 import { ClaimSet } from '../ClaimSet';
 import { Credential } from '../Credential';
 import { Verifier } from './Verifier';
@@ -16,17 +16,20 @@ export class IriVerifier implements Verifier {
 
   public async verify(credential: Credential): Promise<ClaimSet> {
     const claims = await this.verifier.verify(credential);
-    return {
-      ...claims,
-      ...typeof claims[WEBID] === 'string' ? { [WEBID]: this.toIri(claims[WEBID]) } : {},
-      ...typeof claims[CLIENTID] === 'string' ? { [CLIENTID]: this.toIri(claims[CLIENTID]) } : {},
-    };
-  }
+    const result = { ...claims };
 
-  protected toIri(value: string): string {
-    if (isIri(value)) {
-      return value;
+    const original: Record<string, string> = {};
+    for (const claim of [WEBID, CLIENTID]) {
+      if (typeof claims[claim] === 'string' && !isIri(claims[claim])) {
+        result[claim] = joinUrl(this.baseUrl, encodeURIComponent(claims[claim]));
+        original[claim] = claims[claim];
+      }
     }
-    return joinUrl(this.baseUrl, encodeURIComponent(value));
+
+    if (Object.keys(original).length > 0) {
+      result[ORIGINAL] = original;
+    }
+
+    return result;
   }
 }

--- a/packages/uma/src/dialog/BaseNegotiator.ts
+++ b/packages/uma/src/dialog/BaseNegotiator.ts
@@ -1,6 +1,7 @@
 import { BadRequestHttpError, ForbiddenHttpError, HttpErrorClass, KeyValueStorage } from '@solid/community-server';
 import { getLoggerFor } from 'global-logger-factory';
 import { randomUUID } from 'node:crypto';
+import { WEBID } from '../credentials/Claims';
 import { Verifier } from '../credentials/verify/Verifier';
 import { NeedInfoError, RequiredClaim } from '../errors/NeedInfoError';
 import { getOperationLogger } from '../logging/OperationLogger';
@@ -59,7 +60,10 @@ export class BaseNegotiator implements Negotiator {
       const partial = this.isPartialResult(updatedTicket.permissions, resolved.value);
 
       // Retrieve / create instantiated policy
-      const { token, tokenType } = await this.tokenFactory.serialize({ permissions: resolved.value });
+      const { token, tokenType } = await this.tokenFactory.serialize({
+        permissions: resolved.value,
+        ...(typeof updatedTicket.provided[WEBID] === 'string' ? { sub: updatedTicket.provided[WEBID] } : {}),
+      });
       this.logger.debug(`Minted token ${JSON.stringify(token)}`);
 
       // TODO:: test logging

--- a/packages/uma/src/dialog/BaseNegotiator.ts
+++ b/packages/uma/src/dialog/BaseNegotiator.ts
@@ -1,7 +1,7 @@
 import { BadRequestHttpError, ForbiddenHttpError, HttpErrorClass, KeyValueStorage } from '@solid/community-server';
 import { getLoggerFor } from 'global-logger-factory';
 import { randomUUID } from 'node:crypto';
-import { WEBID } from '../credentials/Claims';
+import { getOriginalClaimValue, WEBID } from '../credentials/Claims';
 import { Verifier } from '../credentials/verify/Verifier';
 import { NeedInfoError, RequiredClaim } from '../errors/NeedInfoError';
 import { getOperationLogger } from '../logging/OperationLogger';
@@ -58,11 +58,12 @@ export class BaseNegotiator implements Negotiator {
     // ... on success, create Access Token
     if (resolved.success) {
       const partial = this.isPartialResult(updatedTicket.permissions, resolved.value);
+      const tokenSub = getOriginalClaimValue(updatedTicket.provided, WEBID);
 
       // Retrieve / create instantiated policy
       const { token, tokenType } = await this.tokenFactory.serialize({
         permissions: resolved.value,
-        ...(typeof updatedTicket.provided[WEBID] === 'string' ? { sub: updatedTicket.provided[WEBID] } : {}),
+        ...(typeof tokenSub === 'string' ? { sub: tokenSub } : {}),
       });
       this.logger.debug(`Minted token ${JSON.stringify(token)}`);
 

--- a/packages/uma/src/dialog/ContractNegotiator.ts
+++ b/packages/uma/src/dialog/ContractNegotiator.ts
@@ -1,6 +1,6 @@
 import { createErrorMessage, KeyValueStorage } from '@solid/community-server';
 import { getLoggerFor } from 'global-logger-factory';
-import { WEBID } from '../credentials/Claims';
+import { getOriginalClaimValue, WEBID } from '../credentials/Claims';
 import { Verifier } from '../credentials/verify/Verifier';
 import { RequiredClaim } from '../errors/NeedInfoError';
 import { ContractManager } from '../policies/contracts/ContractManager';
@@ -149,11 +149,13 @@ export class ContractNegotiator extends BaseNegotiator {
     let permissions: Permission[] = Object.values(permissionMap);
     this.logger.debug(`granting permissions: ${JSON.stringify(permissions)}`);
 
+    const tokenSub = getOriginalClaimValue(ticket.provided, WEBID);
+
     // Create response
     const tokenContents: AccessToken = {
       permissions,
       contract,
-      ...(typeof ticket.provided[WEBID] === 'string' ? { sub: ticket.provided[WEBID] } : {}),
+      ...(typeof tokenSub === 'string' ? { sub: tokenSub } : {}),
     };
 
     this.logger.debug(`resolved result ${JSON.stringify(contract)}`);

--- a/packages/uma/src/dialog/ContractNegotiator.ts
+++ b/packages/uma/src/dialog/ContractNegotiator.ts
@@ -1,5 +1,6 @@
 import { createErrorMessage, KeyValueStorage } from '@solid/community-server';
 import { getLoggerFor } from 'global-logger-factory';
+import { WEBID } from '../credentials/Claims';
 import { Verifier } from '../credentials/verify/Verifier';
 import { RequiredClaim } from '../errors/NeedInfoError';
 import { ContractManager } from '../policies/contracts/ContractManager';
@@ -66,7 +67,7 @@ export class ContractNegotiator extends BaseNegotiator {
 
     if (result.success) {
       // TODO:
-      return this.toResponse(result.value);
+      return this.toResponse(result.value, updatedTicket);
     }
 
     // ... on failure, deny if no solvable requirements
@@ -121,7 +122,7 @@ export class ContractNegotiator extends BaseNegotiator {
   }
 
   // TODO: name
-  protected async toResponse(contract: ODRLContract): Promise<DialogOutput> {
+  protected async toResponse(contract: ODRLContract, ticket: Ticket): Promise<DialogOutput> {
 
     this.logger.debug(JSON.stringify(contract, null, 2))
 
@@ -149,7 +150,11 @@ export class ContractNegotiator extends BaseNegotiator {
     this.logger.debug(`granting permissions: ${JSON.stringify(permissions)}`);
 
     // Create response
-    const tokenContents: AccessToken = { permissions, contract }
+    const tokenContents: AccessToken = {
+      permissions,
+      contract,
+      ...(typeof ticket.provided[WEBID] === 'string' ? { sub: ticket.provided[WEBID] } : {}),
+    };
 
     this.logger.debug(`resolved result ${JSON.stringify(contract)}`);
 

--- a/packages/uma/src/tokens/AccessToken.ts
+++ b/packages/uma/src/tokens/AccessToken.ts
@@ -4,8 +4,8 @@ import { Type, array, optional as $, string, intersection, optional } from "../u
 
 export const AccessToken = {
   permissions: array(Permission),
+  sub: optional(string),
   contract: optional(ODRLContract)
 }
 
 export type AccessToken = Type<typeof AccessToken>;
-

--- a/packages/uma/src/tokens/JwtTokenFactory.ts
+++ b/packages/uma/src/tokens/JwtTokenFactory.ts
@@ -26,12 +26,14 @@ export class JwtTokenFactory extends TokenFactory {
    * @param issuer - server URL to assign to the issuer field
    * @param tokenStore - stores the link between JWT and access token
    * @param params - additional parameters for the generated JWT
+   * @param addSub - if true, adds a sub claim to the JWT if available in the input token
    */
   constructor(
     protected readonly keyGen: JwkGenerator,
     protected readonly issuer: string,
     protected readonly tokenStore: KeyValueStorage<string, AccessToken>,
     protected readonly params: JwtTokenParams = { expirationTime: '30m', aud: 'solid' },
+    protected readonly addSub = false,
   ) {
     super();
   }
@@ -52,7 +54,7 @@ export class JwtTokenFactory extends TokenFactory {
       .setExpirationTime(this.params.expirationTime)
       .setJti(randomUUID());
 
-    if (token.sub) {
+    if (this.addSub && token.sub) {
       signJwt = signJwt.setSubject(token.sub);
     }
 

--- a/packages/uma/src/tokens/JwtTokenFactory.ts
+++ b/packages/uma/src/tokens/JwtTokenFactory.ts
@@ -44,14 +44,19 @@ export class JwtTokenFactory extends TokenFactory {
   public async serialize(token: AccessToken): Promise<SerializedToken> {
     const key = await this.keyGen.getPrivateKey();
     const jwk = await importJWK(key, key.alg);
-    const jwt = await new SignJWT({ permissions: token.permissions, contract: token.contract })
+    let signJwt = new SignJWT({ permissions: token.permissions, contract: token.contract })
       .setProtectedHeader({ alg: key.alg, kid: key.kid })
       .setIssuedAt()
       .setIssuer(this.issuer)
       .setAudience(this.params.aud ?? AUD)
       .setExpirationTime(this.params.expirationTime)
-      .setJti(randomUUID())
-      .sign(jwk);
+      .setJti(randomUUID());
+
+    if (token.sub) {
+      signJwt = signJwt.setSubject(token.sub);
+    }
+
+    const jwt = await signJwt.sign(jwk);
 
     this.logger.debug(`Issued new JWT Token ${JSON.stringify(token)}`);
     await this.tokenStore.set(jwt, token);
@@ -80,7 +85,10 @@ export class JwtTokenFactory extends TokenFactory {
 
       reType(permissions, array(Permission));
 
-      return { permissions };
+      return {
+        permissions,
+        ...(typeof payload.sub === 'string' ? { sub: payload.sub } : {}),
+      };
     } catch (error: unknown) {
       const msg = `Invalid Access Token provided, error while parsing: ${createErrorMessage(error)}`;
       this.logger.warn(msg);

--- a/packages/uma/test/unit/credentials/Claims.test.ts
+++ b/packages/uma/test/unit/credentials/Claims.test.ts
@@ -1,0 +1,16 @@
+import { getOriginalClaimValue, ORIGINAL, WEBID } from '../../../src/credentials/Claims';
+
+describe('Claims', (): void => {
+  describe('#getOriginalClaimValue', (): void => {
+    it('prefers original claim values when present.', async(): Promise<void> => {
+      expect(getOriginalClaimValue({
+        [WEBID]: 'http://example.com/id/user',
+        [ORIGINAL]: { [WEBID]: 'user' },
+      }, WEBID)).toBe('user');
+    });
+
+    it('falls back to top-level claim values.', async(): Promise<void> => {
+      expect(getOriginalClaimValue({ [WEBID]: 'http://example.com/id/user' }, WEBID)).toBe('http://example.com/id/user');
+    });
+  });
+});

--- a/packages/uma/test/unit/credentials/verify/IriVerifier.test.ts
+++ b/packages/uma/test/unit/credentials/verify/IriVerifier.test.ts
@@ -1,5 +1,5 @@
 import { Mocked } from 'vitest';
-import { CLIENTID, WEBID } from '../../../../src/credentials/Claims';
+import { CLIENTID, ORIGINAL, WEBID } from '../../../../src/credentials/Claims';
 import { Credential } from '../../../../src/credentials/Credential';
 import { IriVerifier } from '../../../../src/credentials/verify/IriVerifier';
 import { Verifier } from '../../../../src/credentials/verify/Verifier';
@@ -42,6 +42,10 @@ describe('IriVerifier', (): void => {
     await expect(verifier.verify(credential)).resolves.toEqual({
       [WEBID]: 'http://example.com/id/webId',
       [CLIENTID]: 'http://example.com/id/clientId',
+      [ORIGINAL]: {
+        [WEBID]: 'webId',
+        [CLIENTID]: 'clientId',
+      },
       fruit: 'http://example.org/apple',
     });
     expect(source.verify).toHaveBeenCalledTimes(1);

--- a/packages/uma/test/unit/dialog/BaseNegotiator.test.ts
+++ b/packages/uma/test/unit/dialog/BaseNegotiator.test.ts
@@ -1,5 +1,6 @@
 import { ForbiddenHttpError, KeyValueStorage } from '@solid/community-server';
 import { Mocked } from 'vitest';
+import { WEBID } from '../../../src/credentials/Claims';
 import { ClaimSet } from '../../../src/credentials/ClaimSet';
 import { Verifier } from '../../../src/credentials/verify/Verifier';
 import { BaseNegotiator } from '../../../src/dialog/BaseNegotiator';
@@ -170,6 +171,22 @@ describe('BaseNegotiator', (): void => {
     expect(verifier.verify).toHaveBeenCalledWith({ token: 'token2', format: 'format2' });
     expect(ticketingStrategy.validateClaims).toHaveBeenCalledTimes(2);
     expect(ticketingStrategy.validateClaims).toHaveBeenCalledWith(ticket, claims);
+  });
+
+  it('includes the WEBID claim in generated tokens as sub value.', async(): Promise<void> => {
+    const webId = 'https://example.com/profile/card#me';
+    ticketingStrategy.validateClaims.mockResolvedValueOnce({
+      ...ticket,
+      provided: { [WEBID]: webId },
+    });
+
+    await expect(negotiator.negotiate({ ...input, claim_token: 'token', claim_token_format: 'format' })).resolves
+      .toEqual({ access_token: 'token', token_type: 'type' });
+
+    expect(tokenFactory.serialize).toHaveBeenLastCalledWith({
+      permissions: [ { resource_id: 'id1', resource_scopes: [ 'scope1' ] } ],
+      sub: webId,
+    });
   });
 
   it('includes partial=true when resolved permissions do not cover all requested scopes.', async(): Promise<void> => {

--- a/packages/uma/test/unit/dialog/BaseNegotiator.test.ts
+++ b/packages/uma/test/unit/dialog/BaseNegotiator.test.ts
@@ -1,6 +1,6 @@
 import { ForbiddenHttpError, KeyValueStorage } from '@solid/community-server';
 import { Mocked } from 'vitest';
-import { WEBID } from '../../../src/credentials/Claims';
+import { ORIGINAL, WEBID } from '../../../src/credentials/Claims';
 import { ClaimSet } from '../../../src/credentials/ClaimSet';
 import { Verifier } from '../../../src/credentials/verify/Verifier';
 import { BaseNegotiator } from '../../../src/dialog/BaseNegotiator';
@@ -186,6 +186,26 @@ describe('BaseNegotiator', (): void => {
     expect(tokenFactory.serialize).toHaveBeenLastCalledWith({
       permissions: [ { resource_id: 'id1', resource_scopes: [ 'scope1' ] } ],
       sub: webId,
+    });
+  });
+
+  it('prefers the original WEBID claim over the normalized value for token sub.', async(): Promise<void> => {
+    ticketingStrategy.validateClaims.mockResolvedValueOnce({
+      ...ticket,
+      provided: {
+        [WEBID]: 'http://example.com/id/user',
+        [ORIGINAL]: {
+          [WEBID]: 'user',
+        },
+      },
+    });
+
+    await expect(negotiator.negotiate({ ...input, claim_token: 'token', claim_token_format: 'format' })).resolves
+      .toEqual({ access_token: 'token', token_type: 'type' });
+
+    expect(tokenFactory.serialize).toHaveBeenLastCalledWith({
+      permissions: [ { resource_id: 'id1', resource_scopes: [ 'scope1' ] } ],
+      sub: 'user',
     });
   });
 

--- a/packages/uma/test/unit/dialog/ContractNegotiator.test.ts
+++ b/packages/uma/test/unit/dialog/ContractNegotiator.test.ts
@@ -1,6 +1,6 @@
 import { ForbiddenHttpError, KeyValueStorage } from '@solid/community-server';
 import { Mocked, MockInstance } from 'vitest';
-import { WEBID } from '../../../src/credentials/Claims';
+import { ORIGINAL, WEBID } from '../../../src/credentials/Claims';
 import { ClaimSet } from '../../../src/credentials/ClaimSet';
 import { Verifier } from '../../../src/credentials/verify/Verifier';
 import { ContractNegotiator } from '../../../src/dialog/ContractNegotiator';
@@ -150,6 +150,27 @@ describe('ContractNegotiator', (): void => {
       contract,
       permissions: [{ resource_id: 'target', resource_scopes: [ 'https://w3id.org/oac#action' ] }],
       sub: webId,
+    });
+  });
+
+  it('prefers the original WEBID claim over the normalized value for token sub.', async(): Promise<void> => {
+    ticketingStrategy.validateClaims.mockResolvedValueOnce({
+      ...ticket,
+      provided: {
+        [WEBID]: 'http://example.com/id/user',
+        [ORIGINAL]: {
+          [WEBID]: 'user',
+        },
+      },
+    });
+
+    await expect(negotiator.negotiate({ ...input, claim_token: 'token', claim_token_format: 'format' })).resolves
+      .toEqual({ access_token: 'token', token_type: 'type' });
+
+    expect(tokenFactory.serialize).toHaveBeenLastCalledWith({
+      contract,
+      permissions: [{ resource_id: 'target', resource_scopes: [ 'https://w3id.org/oac#action' ] }],
+      sub: 'user',
     });
   });
 });

--- a/packages/uma/test/unit/dialog/ContractNegotiator.test.ts
+++ b/packages/uma/test/unit/dialog/ContractNegotiator.test.ts
@@ -1,5 +1,6 @@
 import { ForbiddenHttpError, KeyValueStorage } from '@solid/community-server';
 import { Mocked, MockInstance } from 'vitest';
+import { WEBID } from '../../../src/credentials/Claims';
 import { ClaimSet } from '../../../src/credentials/ClaimSet';
 import { Verifier } from '../../../src/credentials/verify/Verifier';
 import { ContractNegotiator } from '../../../src/dialog/ContractNegotiator';
@@ -9,13 +10,6 @@ import { TicketingStrategy } from '../../../src/ticketing/strategy/TicketingStra
 import { Ticket } from '../../../src/ticketing/Ticket';
 import { SerializedToken, TokenFactory } from '../../../src/tokens/TokenFactory';
 import { ODRLContract } from '../../../src/views/Contract';
-
-// vi.mock('../../../src/policies/contracts/ContractManager', () => ({
-//   ContractManager: vi.fn().mockReturnValue({
-//     createContract: vi.fn(),
-//     findContract: vi.fn(),
-//   }),
-// }))
 
 describe('ContractNegotiator', (): void => {
   const input: DialogInput = {
@@ -27,7 +21,6 @@ describe('ContractNegotiator', (): void => {
   const claims: ClaimSet = { claim1: 'value1', claim2: 'value2' };
   const ticket: Ticket = {
     permissions: [ { resource_id: 'id1', resource_scopes: [ 'scope1' ] } ],
-    required: [],
     provided: { claim: 'value' },
   };
   const token: SerializedToken = { token: 'token', tokenType: 'type' };
@@ -141,5 +134,22 @@ describe('ContractNegotiator', (): void => {
     ticketingStrategy.resolveTicket.mockResolvedValueOnce({ success: false, value: [] });
     await expect(negotiator.negotiate(input)).rejects.toThrow(ForbiddenHttpError);
     expect(ticketStore.set).toHaveBeenCalledTimes(0);
+  });
+
+  it('includes the WEBID claim in generated tokens as sub value.', async(): Promise<void> => {
+    const webId = 'https://example.com/profile/card#me';
+    ticketingStrategy.validateClaims.mockResolvedValueOnce({
+      ...ticket,
+      provided: { [WEBID]: webId },
+    });
+
+    await expect(negotiator.negotiate({ ...input, claim_token: 'token', claim_token_format: 'format' })).resolves
+      .toEqual({ access_token: 'token', token_type: 'type' });
+
+    expect(tokenFactory.serialize).toHaveBeenLastCalledWith({
+      contract,
+      permissions: [{ resource_id: 'target', resource_scopes: [ 'https://w3id.org/oac#action' ] }],
+      sub: webId,
+    });
   });
 });

--- a/packages/uma/test/unit/tokens/JwtTokenFactory.test.ts
+++ b/packages/uma/test/unit/tokens/JwtTokenFactory.test.ts
@@ -20,6 +20,7 @@ describe('JwtTokenFactory', (): void => {
 
   const token: AccessToken = {
     permissions: [ { resource_id: 'id', resource_scopes: [ 'scopes' ]} ],
+    sub: 'https://example.com/profile/card#me',
     contract: {
       uid: 'uid',
       permission: [{
@@ -60,7 +61,9 @@ describe('JwtTokenFactory', (): void => {
     expect(result.tokenType).toBe('Bearer');
     const parsed = await jwtVerify(result.token, keys.publicKey);
     expect(parsed.payload).toEqual({
-      ...token,
+      permissions: token.permissions,
+      contract: token.contract,
+      sub: token.sub,
       iat: Math.floor(now.getTime()/1000),
       iss: issuer,
       aud: 'solid',
@@ -79,7 +82,10 @@ describe('JwtTokenFactory', (): void => {
       .setIssuer(issuer)
       .setAudience('solid')
       .sign(keys.privateKey);
-    await expect(factory.deserialize(jwt)).resolves.toEqual({ permissions: token.permissions });
+    await expect(factory.deserialize(jwt)).resolves.toEqual({
+      permissions: token.permissions,
+      sub: token.sub,
+    });
   });
 
   it('errors deserializing tokens with no aud field.', async(): Promise<void> => {

--- a/packages/uma/test/unit/tokens/JwtTokenFactory.test.ts
+++ b/packages/uma/test/unit/tokens/JwtTokenFactory.test.ts
@@ -1,5 +1,5 @@
 import { AlgJwk, JwkGenerator, KeyValueStorage } from '@solid/community-server';
-import { exportJWK, generateKeyPair, GenerateKeyPairResult, jwtVerify, KeyLike, SignJWT } from 'jose';
+import { exportJWK, generateKeyPair, GenerateKeyPairResult, jwtVerify, SignJWT } from 'jose';
 import { beforeAll, Mocked } from 'vitest';
 import { AccessToken } from '../../../src/tokens/AccessToken';
 import { JwtTokenFactory } from '../../../src/tokens/JwtTokenFactory';
@@ -63,7 +63,6 @@ describe('JwtTokenFactory', (): void => {
     expect(parsed.payload).toEqual({
       permissions: token.permissions,
       contract: token.contract,
-      sub: token.sub,
       iat: Math.floor(now.getTime()/1000),
       iss: issuer,
       aud: 'solid',
@@ -115,5 +114,22 @@ describe('JwtTokenFactory', (): void => {
       .sign(keys.privateKey);
     await expect(factory.deserialize(jwt)).rejects
       .toThrow('Invalid Access Token provided, error while parsing: value is not an array');
+  });
+
+  it('includes the sub claim when addSub is true.', async(): Promise<void> => {
+    const factoryWithSub = new JwtTokenFactory(keyGen, issuer, tokenStore, undefined, true);
+    const result = await factoryWithSub.serialize(token);
+    const parsed = await jwtVerify(result.token, keys.publicKey);
+    expect(parsed.payload.sub).toBe(token.sub);
+    expect(parsed.payload).toEqual({
+      permissions: token.permissions,
+      contract: token.contract,
+      sub: token.sub,
+      iat: Math.floor(now.getTime()/1000),
+      iss: issuer,
+      aud: 'solid',
+      exp: Math.floor(now.getTime()/1000) + 30 * 60,
+      jti: '1-2-3-4-5',
+    });
   });
 });

--- a/test/integration/Oidc.test.ts
+++ b/test/integration/Oidc.test.ts
@@ -26,7 +26,10 @@ describe('A server supporting OIDC tokens', (): void => {
 
     umaApp = await instantiateFromConfig(
       'urn:uma:default:App',
-      path.join(__dirname, '../../packages/uma/config/default.json'),
+      [
+        path.join(__dirname, '../../packages/uma/config/default.json'),
+        path.join(__dirname, '../../packages/uma/config/enable-sub.json')
+      ],
       {
         'urn:uma:variables:port': umaPort,
         'urn:uma:variables:baseUrl': `http://localhost:${umaPort}/uma`,

--- a/test/integration/Oidc.test.ts
+++ b/test/integration/Oidc.test.ts
@@ -1,6 +1,6 @@
 import { AlgJwk, App, CachedJwkGenerator, MemoryMapStorage } from '@solid/community-server';
 import { setGlobalLoggerFactory, WinstonLoggerFactory } from 'global-logger-factory';
-import { importJWK, SignJWT } from 'jose';
+import { decodeJwt, importJWK, SignJWT } from 'jose';
 import { randomUUID } from 'node:crypto';
 import { createServer, Server } from 'node:http';
 import path from 'node:path';
@@ -156,6 +156,11 @@ describe('A server supporting OIDC tokens', (): void => {
         body: JSON.stringify(content),
       });
       expect(response.status).toBe(200);
+
+      const { access_token } = await response.json() as { access_token: string };
+      const payload = decodeJwt(access_token);
+      expect(payload.sub).toBe(sub);
+      expect(payload.sub).not.toBe(`http://example.com/id/${sub}`);
     });
   });
 


### PR DESCRIPTION
This is also a potential "for now" solution. This couples the RS and AS a bit more, and perhaps too much. In the future we might instead want to return a more opaque value there which stays the same for the same input identity, but does not leak the actual identity. Depends a bit on the use case being solved.